### PR TITLE
fixed brk and added inspect-port

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -50,6 +50,11 @@ class CLI {
         describe: 'To break on the first line of the application code.',
         boolean: true
       })
+      .option('inspect-port', {
+        alias: 'p',
+        describe: 'Debug port. Defaults to 9229. (Passes through to node)',
+        type: 'number'
+      })
       .option('silent', {
         alias: 's',
         describe: 'Hide stdout/stderr output from child process.',
@@ -74,7 +79,10 @@ class CLI {
   exec () {
     let o = process.argv
     let args = o.splice(o.indexOf(this.args._[2]), o.length).join(' ')
-    let cmd = (this.args._.brk) ? '--inspect-brk' : '--inspect'
+    let cmd = (this.args.brk) ? '--inspect-brk' : '--inspect'
+    if (this.args.inspectPort) {
+      cmd += ` --inspect-port=${this.args.inspectPort}`;
+    }
     this.child = exec(`node ${cmd} ${args}`, { shell: true })
     this.child.stdout.on('data', this.handle.bind(this))
     this.child.stderr.on('data', this.handle.bind(this))

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,6 +45,11 @@ class CLI {
         describe: 'Run the devtools in canary.',
         boolean: true
       })
+      .option('nodemon', {
+        alias: 'nm',
+        describe: 'Use nodemon.',
+        boolean: true
+      })
       .option('inspect-brk', {
         alias: 'brk',
         describe: 'To break on the first line of the application code.',
@@ -77,13 +82,14 @@ class CLI {
   }
 
   exec () {
+    let binary = this.args.nodemon ? 'nodemon' : node
     let o = process.argv
     let args = o.splice(o.indexOf(this.args._[2]), o.length).join(' ')
     let cmd = (this.args.brk) ? '--inspect-brk' : '--inspect'
     if (this.args.inspectPort) {
-      cmd += ` --inspect-port=${this.args.inspectPort}`;
+      cmd += ` --inspect-port=${this.args.inspectPort}`
     }
-    this.child = exec(`node ${cmd} ${args}`, { shell: true })
+    this.child = exec(`${binary} ${cmd} ${args}`, { shell: true })
     this.child.stdout.on('data', this.handle.bind(this))
     this.child.stderr.on('data', this.handle.bind(this))
     this.child.on('close', _ => process.exit())

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -82,7 +82,7 @@ class CLI {
   }
 
   exec () {
-    let binary = this.args.nodemon ? 'nodemon' : node
+    let binary = this.args.nodemon ? 'nodemon' : 'node'
     let o = process.argv
     let args = o.splice(o.indexOf(this.args._[2]), o.length).join(' ')
     let cmd = (this.args.brk) ? '--inspect-brk' : '--inspect'


### PR DESCRIPTION
Fixed brk flag, and now can specify --inspect-port, which allows you to have multiple debug sessions going at once. 

##### Checklist

- [X] `$ npm test` passes
- [ ] tests are included
- [ ] documentation is changed and/or added
- [ ] commit message follows [commit guidelines](https://github.com/darcyclarke/rawkit/CONTRIBUTING.md#commit-message-guidelines)
