### PR TITLE
cli: add executable option

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -18,7 +18,7 @@ class CLI {
     this.image = { path: '../extension/icon.png', type: 'image/png' }
     this.index = { path: '../extension/index.html', type: 'text/html' }
     this.caught = false
-    this.browser = `google chrome ${this.args.canary ? 'canary' : ''}`.trim()
+    this.browser = `${this.args.executable} ${this.args.canary ? 'canary' : ''}`.trim()
   }
 
   get props () {
@@ -40,6 +40,11 @@ class CLI {
       .help('help')
       .usage('Usage: $0 -x [num]')
       .showHelpOnFail(false, 'Specify --help for available options')
+      .option('executable', {
+        alias: 'e',
+        describe: 'Specify the name of the executable.',
+        default: 'google chrome'
+      })
       .option('canary', {
         alias: 'c',
         describe: 'Run the devtools in canary.',


### PR DESCRIPTION
Hi there,
I was giving rawkit a try (I run a Kubuntu, basically a Ubuntu with KDE), everything's working just fine beside a little change I had to do there:
https://github.com/darcyclarke/rawkit/blob/862920fb519dca97fc938478dcb15df3a3f82cd5/bin/cli.js#L21

My executable is called `google-chrome` (rather than `google chrome`).

I find rawkit really sweet and I though I could make a little PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `$ npm test` passes
- [ ] tests are included
- [x] commit message follows [commit guidelines](https://github.com/darcyclarke/rawkit/CONTRIBUTING.md#commit-message-guidelines)
